### PR TITLE
Fix inverted Dock static-only logic

### DIFF
--- a/config/profile.zsh
+++ b/config/profile.zsh
@@ -6,9 +6,9 @@ if [[ "$USER" == "$MATCH_USERNAME" ]]; then
 
   echo && echo "==> System preferences..."
   if [[ ! -f ~/.logs/.brewdock.lock ]]; then
-    defaults write com.apple.dock static-only -bool true && touch ~/.logs/.brewdock.lock
-  else
-    defaults write com.apple.dock static-only -bool false && killall Dock
+    defaults write com.apple.dock static-only -bool true
+    killall Dock
+    touch ~/.logs/.brewdock.lock
   fi
 
   preferences=(


### PR DESCRIPTION
## Summary
- The `else` branch in profile.zsh was undoing the `static-only` setting and restarting Dock on every run after the lock file existed
- Now only sets the preference once (when lock file doesn't exist) and skips on subsequent runs

## Test plan
- [ ] Delete `~/.logs/.brewdock.lock` and run profile.zsh — Dock should restart with static-only enabled
- [ ] Run again — should skip the Dock section entirely