### PR TITLE
Fix rename() exit code check

### DIFF
--- a/config/fx.zsh
+++ b/config/fx.zsh
@@ -167,9 +167,8 @@ killport() {
 # Rename current working directory or existing directory
 rename() {
   if [[ "$#" == "1" ]]; then
-    [ ! -d "../$1/" ] && rsync -a "$(pwd)/" "../$1" && rm -rf "$(pwd)/" && cd "../$1/"
-    if [[ $? == 0 && "$TERM_PROGRAM" == "cursor" ]]; then
-      cursor -r .
+    if [ ! -d "../$1/" ] && rsync -a "$(pwd)/" "../$1" && rm -rf "$(pwd)/" && cd "../$1/"; then
+      [[ "$TERM_PROGRAM" == "cursor" ]] && cursor -r .
     fi
   elif [[ "$#" == "2" ]]; then
     [ ! -d "$2/" ] && rsync -a "$1/" "$2" && rm -rf "$1/"


### PR DESCRIPTION
## Summary
- `$?` after a `&&` chain always reflects the last command, not the overall result
- Wrapped the chain in an `if` block so cursor reload only runs on success

## Test plan
- [ ] `rename newname` in a directory — should rename and open in cursor if applicable
- [ ] `rename newname` when `../newname` already exists — should not attempt rename or open cursor