### PR TITLE
Fix ls alias breaking with directory arguments

### DIFF
--- a/config/alias.zsh
+++ b/config/alias.zsh
@@ -1,6 +1,6 @@
 alias c="cursor ."
 alias cr="cursor -r ."
-alias ls="ls -A --color | sort"
+ls() { command ls -A --color "$@" | sort; }
 alias mkcd='cdx'
 alias trash='rm'
 


### PR DESCRIPTION
## Summary
- `alias ls="ls -A --color | sort"` causes `ls somedir` to fail because `sort` gets the arg, not `ls`
- Changed to a function wrapper so arguments are passed correctly to `ls`

## Test plan
- [ ] `ls` in current directory — lists sorted files
- [ ] `ls /tmp` — lists sorted files in /tmp