### PR TITLE
Fix lock file creating symlink to itself

### DIFF
--- a/config/background.zsh
+++ b/config/background.zsh
@@ -47,7 +47,7 @@ fi
 
 if [ $TIME_DIFF -gt $INTERVAL ]; then
   # Create a lock using `ln`
-  if ln -s "$LOCK_FILE" "$LOCK_FILE.lock" 2>/dev/null; then
+  if ln -s $$ "$LOCK_FILE" 2>/dev/null; then
     # Set Zsh options to suppress job control notifications
     setopt NO_MONITOR NO_NOTIFY
 
@@ -68,7 +68,7 @@ if [ $TIME_DIFF -gt $INTERVAL ]; then
 
     # Start the background task with nohup
     nohup zsh -c "
-      trap 'rm -f \"$LOCK_FILE.lock\"' EXIT
+      trap 'rm -f \"$LOCK_FILE\"' EXIT
 
       # Log the start time
       echo \"$(date +"%Y-%m-%d %H:%M:%S") > ZSHIFY_BACKROUND_RUN\" >> \"$LOG_FILE\"


### PR DESCRIPTION
## Summary
- `ln -s "$LOCK_FILE" "$LOCK_FILE.lock"` was creating a symlink pointing at itself
- Changed to `ln -s $$ "$LOCK_FILE"` which atomically creates a lock containing the PID
- Fixed trap to clean up the correct file path on exit

## Test plan
- [ ] Open a new shell — background task should acquire lock and run
- [ ] Open another shell quickly — should log "already running" instead of deadlocking
- [ ] After background task finishes, lock file should be cleaned up