### PR TITLE
Fix npm/npx wrappers breaking on args with spaces

### DIFF
--- a/config/fx.zsh
+++ b/config/fx.zsh
@@ -259,7 +259,8 @@ if command -v bun &>/dev/null; then
     if [[ "$*" == *"--real"* ]] || [[ -n "$USE_REAL_NPM" ]]; then
       export USE_REAL_NPM=1
       trap 'unset USE_REAL_NPM' EXIT
-      command npm $(echo "${@/--real/}" | xargs)
+      local args=("${@/--real/}")
+      command npm "${args[@]}"
     else
       bun "$@"
     fi
@@ -268,7 +269,8 @@ if command -v bun &>/dev/null; then
     if [[ "$*" == *"--real"* ]] || [[ -n "$USE_REAL_NPX" ]]; then
       export USE_REAL_NPX=1
       trap 'unset USE_REAL_NPX' EXIT
-      command npx $(echo "${@/--real/}" | xargs)
+      local args=("${@/--real/}")
+      command npx "${args[@]}"
     else
       bunx "$@"
     fi


### PR DESCRIPTION
## Summary
- `echo "${@/--real/}" | xargs` strips quotes and splits args containing spaces
- Use zsh array manipulation instead to preserve argument boundaries

## Test plan
- [ ] `npm --real install "some package"` passes args correctly to real npm
- [ ] `npm install something` still delegates to bun