### PR TITLE
Cache package.json deps in prompt until directory changes

### DIFF
--- a/config/prompt.zsh
+++ b/config/prompt.zsh
@@ -15,16 +15,15 @@ preexec() {
 }
 
 precmd() {
-  # if [ $? -ne 0 ]; then
-  #   run a command if the last command failed
-  # fi
-  # get the number of dependencies in package.json
-  DEPS=$(jq '.dependencies | length' package.json 2>/dev/null)
-  DEVDEPS=$(jq '.devDependencies | length' package.json 2>/dev/null)
-  DEPS=$([ "$DEPS" -eq 0 ] 2>/dev/null && echo "" || echo " 📦$DEPS")
-  DEVDEPS=$([ "$DEVDEPS" -eq 0 ] 2>/dev/null && echo "" || echo " 💠$DEVDEPS")
-  DEPS="$DEVDEPS$DEPS"
-  # get the current branch
+  # Recompute deps and branch only when directory changes
+  if [[ "$PWD" != "$_PROMPT_LAST_PWD" ]]; then
+    _PROMPT_LAST_PWD="$PWD"
+    DEPS=$(jq '.dependencies | length' package.json 2>/dev/null)
+    DEVDEPS=$(jq '.devDependencies | length' package.json 2>/dev/null)
+    DEPS=$([ "$DEPS" -eq 0 ] 2>/dev/null && echo "" || echo " 📦$DEPS")
+    DEVDEPS=$([ "$DEVDEPS" -eq 0 ] 2>/dev/null && echo "" || echo " 💠$DEVDEPS")
+    DEPS="$DEVDEPS$DEPS"
+  fi
   CURRENT_BRANCH=$(git branch --show-current 2>/dev/null)
   [[ "$(fc -ln -1)" == "clear" ]] && START=""
   # set the prompt to the current user, directory, branch, and dependencies


### PR DESCRIPTION
## Summary
- `jq` was invoked twice on every prompt to count deps/devDeps, even when PWD hadn't changed
- Now caches the result and only recomputes when directory changes
- Git branch is still checked every prompt since it can change without a `cd`

## Test plan
- [ ] Open shell in a Node project — deps show in prompt
- [ ] Run a few commands in same directory — no jq overhead
- [ ] `cd` to another project — deps update correctly