### PR TITLE
Fix killport process tree and remove ctrl+z toggle

### DIFF
--- a/config/fx.zsh
+++ b/config/fx.zsh
@@ -153,7 +153,16 @@ killport() {
       return 0
     fi
   else
-    pids=$(pgrep -f "$target")
+    # Match by name + find all child processes
+    pids=$(pgrep -f "$target" 2>/dev/null)
+    if [[ -n "$pids" ]]; then
+      # Also find children of matched processes
+      local children=""
+      for pid in ${(f)pids}; do
+        children+=$(pgrep -P "$pid" 2>/dev/null)$'\n'
+      done
+      pids=$(echo "$pids"$'\n'"$children" | sort -u | grep -v '^$')
+    fi
     if [[ -z "$pids" ]]; then
       echo "No processes found matching name \"$target\""
       return 0


### PR DESCRIPTION
## Summary
- `killport node` now kills matching processes and all their children via `pgrep -P`
- Removed ctrl+z toggle widget (incompatible with Cursor terminal)
- Removed suspended job count from prompt

## Test plan
- [ ] `killport node` kills next-server and other child processes
- [ ] `killport 3000` still works by port
- [ ] Ctrl+Z works normally (default suspend)