### PR TITLE
enhancement: stash with no args lists stashes

### DIFF
--- a/config/fx.zsh
+++ b/config/fx.zsh
@@ -102,10 +102,15 @@ alias add="ga"
 stash() {
   local name="$1"
   if [[ -z "$name" ]]; then
-    git stash push
-  else
-    git stash push -m "$name"
+    local list=$(git stash list 2>/dev/null)
+    if [[ -z "$list" ]]; then
+      echo "No stashes found"
+    else
+      echo "$list"
+    fi
+    return
   fi
+  git stash push -m "$name"
 }
 
 pop() {


### PR DESCRIPTION
## Summary
- `stash` with no args now shows `git stash list` instead of doing a blind push
- Prevents accidental unnamed stashes

## Test plan
- [ ] Run `stash` with no args — should list stashes or show "No stashes found"
- [ ] Run `stash myname` — should still push with message
- [ ] `pop` behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)