### PR TITLE
enhancement: fallback to zoxide cd on unknown commands

### DIFF
--- a/config/user.zsh
+++ b/config/user.zsh
@@ -12,3 +12,16 @@ command -v fzf &>/dev/null && source <(fzf --zsh)
 
 # zoxide
 command -v zoxide &>/dev/null && eval "$(zoxide init zsh)"
+
+# If command not found, try zoxide cd
+_zoxide_accept_line() {
+  local cmd="${BUFFER%% *}"
+  if [[ -n "$cmd" ]] && ! whence "$cmd" &>/dev/null; then
+    local dir=$(zoxide query "$cmd" 2>/dev/null)
+    if [[ -n "$dir" ]]; then
+      BUFFER="cd ${(q)dir}"
+    fi
+  fi
+  zle .accept-line
+}
+zle -N accept-line _zoxide_accept_line


### PR DESCRIPTION
## Summary
- Typing an unknown command that matches a zoxide directory now `cd`s there instead of showing "command not found"
- Uses `accept-line` widget to intercept before execution, avoiding zsh's sandboxed `command_not_found_handler`

## Test plan
- [ ] `exec zsh` to reload
- [ ] Type a directory name known to zoxide (e.g. `zerostarter`) — should cd there
- [ ] Type a real command (e.g. `ls`) — should work normally
- [ ] Type a truly unknown word — should show "command not found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)