### PR TITLE
fix: prevent background tasks from leaking to terminal

### DIFF
--- a/config/background.zsh
+++ b/config/background.zsh
@@ -66,16 +66,24 @@ if [ $TIME_DIFF -gt $INTERVAL ]; then
       done
     ' _ {} +
 
-    # Start the background task with nohup
+    # Start the background task fully detached from terminal
     nohup zsh -c "
       trap 'rm -f \"$LOCK_FILE.lock\"' EXIT
 
-      # Log the start time
-      echo \"$(date +"%Y-%m-%d %H:%M:%S") > ZSHIFY_BACKROUND_RUN\" >> \"$LOG_FILE\"
+      # Detach from controlling terminal
+      exec </dev/null >/dev/null 2>/dev/null
 
-      # Source profile
-      source ~/.zshify/config/profile.zsh
-    " >>"$LOG_FILE" 2>&1 </dev/null &
+      # Ensure no interactive prompts
+      export NONINTERACTIVE=1
+      export HOMEBREW_NO_AUTO_UPDATE=1
+      export SUDO_ASKPASS=/usr/bin/false
+
+      # Log the start time
+      echo \"\$(date +\"%Y-%m-%d %H:%M:%S\") > ZSHIFY_BACKROUND_RUN\" >> \"$LOG_FILE\"
+
+      # Source profile, capture all output to log
+      source ~/.zshify/config/profile.zsh >> \"$LOG_FILE\" 2>&1
+    " </dev/null >>"$LOG_FILE" 2>&1 &
 
     # Detach the process
     disown


### PR DESCRIPTION
## Summary
- Fully detach background process from controlling terminal with `exec </dev/null >/dev/null 2>/dev/null`
- Set `NONINTERACTIVE=1`, `HOMEBREW_NO_AUTO_UPDATE=1`, and `SUDO_ASKPASS=/usr/bin/false` to prevent any interactive prompts
- Redirect profile.zsh output to log file instead of inherited stdio

## Test plan
- [x] Verified background process produces no terminal output
- [x] Verified sudo fails silently instead of prompting for password
- [x] Verified all output is captured in log file

🤖 Generated with [Claude Code](https://claude.com/claude-code)