### PR TITLE
enhancement: add bat as cat override

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Why not change it to it's minimal yet advanced version? And that too with colors
 
 ```sh
 # to enrich your terminal experience run this command after installing brew
-brew install zsh-autosuggestions zsh-history-substring-search zsh-syntax-highlighting fzf zoxide
+brew install bat zsh-autosuggestions zsh-history-substring-search zsh-syntax-highlighting fzf zoxide
 ```
 
 ## What's Included
@@ -46,6 +46,7 @@ A minimal, informative prompt showing:
 
 | Command | Description |
 | --- | --- |
+| `cat` | Uses `bat` for syntax-highlighted output (no pager, no line numbers) when available |
 | `ls` | Enhanced ls with hidden files, color, and sorting (no args). Passes through to default ls with flags. |
 | `cdx <dir>` | Create a directory and cd into it |
 | `clone <repo>` | Clone a GitHub repo via `gh` |

--- a/config/fx.zsh
+++ b/config/fx.zsh
@@ -304,6 +304,11 @@ if [[ -o interactive ]]; then
     fi
   }
 
+  # Use bat for syntax-highlighted output (no pager, no line numbers)
+  if command -v bat &>/dev/null; then
+    cat() { bat --paging=never --style=plain "$@"; }
+  fi
+
   # Use bun instead of npm
   if command -v bun &>/dev/null; then
     npm() {

--- a/config/profile.zsh
+++ b/config/profile.zsh
@@ -76,7 +76,7 @@ if [[ "$USER" == "$MATCH_USERNAME" ]]; then
   brew analytics off && brew update
 
   echo && echo "==> Ensuring brew formulae..."
-  brew install -q fnm fzf gh git gnupg jq mas ollama rsync tree zoxide zsh-autosuggestions zsh-history-substring-search zsh-syntax-highlighting
+  brew install -q bat fnm fzf gh git gnupg jq mas ollama rsync tree zoxide zsh-autosuggestions zsh-history-substring-search zsh-syntax-highlighting
 
   echo && echo "==> Ensuring node..."
   eval "$(fnm env)"


### PR DESCRIPTION
## Summary
- Add `bat` to brew formulae in profile.zsh
- Override `cat` with `bat --paging=never --style=plain` in interactive shells
- Update README with new function and install command

## Test plan
- [ ] `cat <file>` shows syntax-highlighted output without pager or line numbers
- [ ] Piped `cat` and non-interactive shells use native `cat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)