### PR TITLE
fix: ls color fallback for stock macOS

### DIFF
--- a/config/fx.zsh
+++ b/config/fx.zsh
@@ -253,7 +253,7 @@ if [[ -o interactive ]]; then
   # show hidden files with color and sorting
   ls() {
     if [[ $# -eq 0 ]]; then
-      command ls -A --color | sort
+      (command ls -A --color 2>/dev/null || command ls -A -G) | sort
     else
       command ls "$@"
     fi


### PR DESCRIPTION
## Summary
- Fall back to BSD `ls -G` when GNU `ls --color` is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)