### PR TITLE
fix: use local zshify.png in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Zshify - A Minimalistic Touch To Your Prompt!
 
-<img src="https://raw.githubusercontent.com/nrjdalal/zshify/master/zshify.png">
+<img src="zshify.png">
 
 Zshify is a minimalistic, one command installation to customize the prompt of your Zshell or Zsh!
 


### PR DESCRIPTION
## Summary
- Use relative path `zshify.png` instead of raw GitHub URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)