### PR TITLE
fix: replace cursor position detection to prevent escape sequence leaks

### DIFF
--- a/config/prompt.zsh
+++ b/config/prompt.zsh
@@ -9,11 +9,12 @@ setopt INC_APPEND_HISTORY_TIME
 setopt RM_STAR_SILENT
 
 [ "$PWD" = "$HOME" ] && cd ~/Desktop
-# newline before prompt unless fresh terminal (cursor at row 1)
+# newline before prompt unless fresh terminal
 START=$'\n'
-print -n '\e[6n' > /dev/tty
-IFS='[;' read -sd R _ _row _ < /dev/tty
-(( _row == 1 )) && START=""
+if [[ -z "$_ZSHIFY_STARTED" ]]; then
+  START=""
+  _ZSHIFY_STARTED=1
+fi
 
 preexec() {
   TIMER=$(print -P %D{%s%3.})


### PR DESCRIPTION
## Summary
- Replaced `\e[6n` cursor position escape sequence with a simple `_ZSHIFY_STARTED` flag
- The escape sequence could race with the terminal response, occasionally leaking `[row;colR` text or triggering zsh's `PROMPT_EOL_MARK` (`%`)

## Test plan
- [ ] Open a new terminal — no `%` or `[row;colR` leak
- [ ] Run `exec zsh` — first newline is skipped cleanly
- [ ] Verify newline spacing between prompts still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)